### PR TITLE
remove thrown exception on findAllById not found

### DIFF
--- a/modules/spring-data/src/main/java/org/stubit/springdata/CrudRepositoryStub.java
+++ b/modules/spring-data/src/main/java/org/stubit/springdata/CrudRepositoryStub.java
@@ -48,10 +48,9 @@ public abstract class CrudRepositoryStub<T, ID> extends RepositoryStub<T, ID>
     List<T> found = new ArrayList<>();
     ids.forEach(
         id -> {
-          if (!data.containsKey(id)) {
-            throw new IllegalArgumentException("No entity with id %s".formatted(id));
+          if (data.containsKey(id)) {
+            found.add(data.get(id));
           }
-          found.add(data.get(id));
         });
     return found;
   }

--- a/modules/spring-data/src/test/java/org/stubit/springdata/CrudRepositoryStubTest.java
+++ b/modules/spring-data/src/test/java/org/stubit/springdata/CrudRepositoryStubTest.java
@@ -3,7 +3,6 @@ package org.stubit.springdata;
 import static java.util.UUID.randomUUID;
 import static java.util.stream.StreamSupport.stream;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 import static org.assertj.core.api.Assumptions.assumeThat;
 
 import java.util.List;
@@ -81,8 +80,7 @@ class CrudRepositoryStubTest {
     var unknownId = randomUUID();
     var ids = List.of(knownEntity.getUuid(), unknownId);
 
-    assertThatExceptionOfType(IllegalArgumentException.class)
-        .isThrownBy(() -> repository.findAllById(ids));
+    assertThat(repository.findAllById(ids)).containsExactly(knownEntity);
   }
 
   @Test

--- a/modules/spring-data/src/test/java/org/stubit/springdata/ListCrudRepositoryStubTest.java
+++ b/modules/spring-data/src/test/java/org/stubit/springdata/ListCrudRepositoryStubTest.java
@@ -3,7 +3,6 @@ package org.stubit.springdata;
 import static java.util.UUID.randomUUID;
 import static java.util.stream.StreamSupport.stream;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 import static org.assertj.core.api.Assumptions.assumeThat;
 
 import java.util.List;
@@ -72,8 +71,7 @@ class ListCrudRepositoryStubTest {
     var unknownId = randomUUID();
     var ids = List.of(knownEntity.getUuid(), unknownId);
 
-    assertThatExceptionOfType(IllegalArgumentException.class)
-        .isThrownBy(() -> repository.findAllById(ids));
+    assertThat(repository.findAllById(ids)).containsExactly(knownEntity);
   }
 
   @Test


### PR DESCRIPTION
spring-data CrudRepository doesn't throw exception if it doesn't find this entry, but it returns a smaller list.
https://docs.spring.io/spring-data/commons/docs/current/api/org/springframework/data/repository/CrudRepository.html#findAllById(java.lang.Iterable)
