### PR TITLE
Use ConcurrentHashMap for thread-safety

### DIFF
--- a/manual/src/docs/asciidoc/chapters/03-spring-data.adoc
+++ b/manual/src/docs/asciidoc/chapters/03-spring-data.adoc
@@ -115,7 +115,7 @@ include::../../../test/kotlin/examples/kotlin/SpringDataDocTest.kt[tag=verify]
 
 == Reusing a Stub
 
-Note that a link:{javadoc-url}/spring-data/org/stubit/springdata/CrudRepositoryStub.html[`CrudRepositoryStub`] is basically a glorified `HashMap`, so we can simply create a new instance for every test.
+Note that a link:{javadoc-url}/spring-data/org/stubit/springdata/CrudRepositoryStub.html[`CrudRepositoryStub`] is basically a glorified `ConcurrentHashMap`, so we can simply create a new instance for every test.
 
 However, that might require to recreate the service as well.
 So, if we want to reuse the stub, we can simply use the `deleteAll` method to clear the stub:

--- a/modules/spring-data/src/main/java/org/stubit/springdata/RepositoryStub.java
+++ b/modules/spring-data/src/main/java/org/stubit/springdata/RepositoryStub.java
@@ -1,20 +1,21 @@
 package org.stubit.springdata;
 
 import java.lang.reflect.Field;
-import java.util.HashMap;
+import java.util.concurrent.ConcurrentHashMap;
 import org.jspecify.annotations.NullMarked;
 import org.springframework.data.repository.Repository;
 
 /**
- * Simple abstract {@link Repository} stub implementation using a {@link HashMap} to store data.
+ * Simple abstract {@link Repository} stub implementation using a {@link ConcurrentHashMap} to store
+ * data.
  *
  * @see Repository
  */
 @NullMarked
 public abstract class RepositoryStub<T, ID> implements Repository<T, ID> {
 
-  /** A {@link HashMap} to store the data. */
-  protected HashMap<ID, T> data = new HashMap<>();
+  /** A {@link ConcurrentHashMap} to store the data. */
+  protected ConcurrentHashMap<ID, T> data = new ConcurrentHashMap<>();
 
   /**
    * Extracts the {@link org.springframework.data.annotation.Id} or {@link jakarta.persistence.Id}

--- a/modules/spring-data/src/test/java/org/stubit/springdata/CrudRepositoryStubTest.java
+++ b/modules/spring-data/src/test/java/org/stubit/springdata/CrudRepositoryStubTest.java
@@ -7,6 +7,7 @@ import static org.assertj.core.api.Assumptions.assumeThat;
 
 import java.util.List;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
 
 class CrudRepositoryStubTest {
@@ -37,6 +38,28 @@ class CrudRepositoryStubTest {
         repository.saveAll(List.of(TestEntity.randomEntity(), TestEntity.randomEntity()));
 
     assertThat(repository.findAllById(idsOf(entities))).isEqualTo(entities);
+  }
+
+  @Test
+  void saveAll_concurrent() {
+    var repository = new TestCrudRepositoryStub();
+    var entities =
+        List.of(
+            List.of(
+                TestEntity.randomEntity(), TestEntity.randomEntity(), TestEntity.randomEntity()),
+            List.of(
+                TestEntity.randomEntity(), TestEntity.randomEntity(), TestEntity.randomEntity()),
+            List.of(
+                TestEntity.randomEntity(), TestEntity.randomEntity(), TestEntity.randomEntity()),
+            List.of(
+                TestEntity.randomEntity(), TestEntity.randomEntity(), TestEntity.randomEntity()),
+            List.of(
+                TestEntity.randomEntity(), TestEntity.randomEntity(), TestEntity.randomEntity()));
+
+    entities.parallelStream().forEach(repository::saveAll);
+
+    assertThat(stream(repository.findAll().spliterator(), false).collect(Collectors.toSet()))
+        .isEqualTo(entities.stream().flatMap(List::stream).collect(Collectors.toSet()));
   }
 
   @Test


### PR DESCRIPTION
HashMap is not thread-safe. Concurrent modification by multiple threads
can lead to inconsistent state.